### PR TITLE
Add script for publishing crates on CI

### DIFF
--- a/publish-crates
+++ b/publish-crates
@@ -609,10 +609,7 @@ main() {
       setup_local_cratesio
     ;;
     default)
-      if
-        [ ! "${was_triggered_manually:-}" ] &&
-        [ "$initial_commit_sha" != "2e21c35f879e904101d8305eef7a203d95dd6cd6" ]
-      then
+      if [ ! "${was_triggered_manually:-}" ]; then
         # TODO: enable it after local instance publishing works for a while on CI
         log "Publishing to crates.io is temporarily disabled"; exit 0
       fi

--- a/publish-crates
+++ b/publish-crates
@@ -717,6 +717,8 @@ main() {
 
   if [ "${should_submit_pr:-}" ] && [ "${has_diff:-}" ] && [ "$subpub_exit_code" -eq 0 ]; then
     git reset -q "$initial_commit_sha"
+    # some other job is saving artifacts to crate-docs ??
+    rm -rf crate-docs
     git add .
     git commit -q -m "update dependencies after publish" -m "generated from $ci_job_url"
 

--- a/publish-crates
+++ b/publish-crates
@@ -73,17 +73,6 @@ setup_local_cratesio() {
 
   git clone --branch releng https://github.com/paritytech/crates.io "$cratesio_repo"
 
-  local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
-
-  # clear the local registry's cache before going forward since the local
-  # registry will be recreated for this job
-  if [ -e "$cargo_home/registry" ]; then
-    find "$cargo_home"/registry -maxdepth 2 -type d -name "-*" -prune -exec rm -rf {} \;
-  fi
-  if [ -e "$cargo_home/git" ]; then
-    find "$cargo_home"/git -maxdepth 2 -type d -name "-*" -prune -exec rm -rf {} \;
-  fi
-
   >/dev/null pushd "$cratesio_repo"
 
   mkdir local_uploads tmp
@@ -144,6 +133,7 @@ setup_local_cratesio() {
 
           # Clear the registry's cache after a crate is committed to the remote
           # registry in order to force its redownload
+          cargo_home="${CARGO_HOME:-$HOME/.cargo}"
           find "$cargo_home" \
             -type d -path "**/$crate-$crate_version" \
             -print \

--- a/publish-crates
+++ b/publish-crates
@@ -437,7 +437,13 @@ setup_repository() {
   local this_file="${BASH_SOURCE[0]}"
   local this_file_dir="${this_file%/*}"
   local this_file_dirname="${this_file_dir##*/}"
-  echo "/.tmp"$'\n'"/$this_file_dirname" > "$tmp/.gitignore"
+
+  local ignores="/.tmp"$'\n'"/$this_file_dirname"
+  if [ "${SPUB_TMP:-}" ]; then
+    ignores+=$'\n'"$SPUB_TMP"
+  fi
+  echo "$ignores" > "$tmp/.gitignore"
+
   git config core.excludesFile "$tmp/.gitignore"
 }
 

--- a/publish-crates
+++ b/publish-crates
@@ -517,10 +517,6 @@ main() {
 
   local subpub_args=(publish --root "$PWD")
 
-  if ! [ "${is_pr_branch:-}" ]; then
-    subpub_args+=(--post-check)
-  fi
-
   local crates_to_publish=()
 
   while IFS= read -r crate; do
@@ -602,6 +598,10 @@ main() {
 
   case "$cratesio_target_instance" in
     local)
+      if [ ! "${is_pr_branch:-}" ]; then
+        subpub_args+=(--post-check)
+      fi
+
       apt update -qq
       setup_postgres
       # diesel setup should be after setup_progress because it depends on libpq

--- a/publish-crates
+++ b/publish-crates
@@ -691,7 +691,7 @@ main() {
 
     if [ "$open_pr_count" -eq 0 ]; then
       local title="Update dependencies after publish"
-      local body="# :exclamation: This PR is generated automatically by CI. DO NOT push commits to this PR!"
+      local body="# :exclamation: DO NOT push commits to this PR! This PR is generated automatically by CI"
       local payload
       payload="$(jq -n \
         --arg title "$title" \

--- a/publish-crates
+++ b/publish-crates
@@ -768,7 +768,7 @@ main() {
         -H "Authorization: token $github_token" \
         -X POST \
         -d "$payload" \
-        "$gh_api/$repo_owner/$repo/pulls"
+        "$gh_api/repos/$repo_owner/$repo/pulls"
     fi
   fi
 

--- a/publish-crates
+++ b/publish-crates
@@ -609,6 +609,10 @@ main() {
     ;;
   esac
 
+  if [ "${should_submit_pr:-}" ]; then
+    subpub_args+=(--for-pull-request)
+  fi
+
   for crate_to_publish in "${crates_to_publish[@]}"; do
     subpub_args+=(--publish-only "$crate_to_publish")
   done

--- a/publish-crates
+++ b/publish-crates
@@ -611,7 +611,7 @@ main() {
   fi
 
   setup_subpub
-  subpub "${subpub_args[@]}" || :
+  subpub "${subpub_args[@]}" || log "::SUBPUB FAILED"
 }
 
 main "$@"

--- a/publish-crates
+++ b/publish-crates
@@ -350,7 +350,9 @@ check_repository() {
   local cratesio_crates_owner="$2"
   local gh_api="$3"
   local this_branch="$4"
-  local is_pr_branch="$5"
+  local repo_owner="$5"
+  local repo="$6"
+  local is_pr_branch="$7"
 
   local selected_crates=()
 
@@ -395,7 +397,7 @@ check_repository() {
       curl -sSLf \
         -H "Accept: application/vnd.github.v3.diff" \
         -H "Authorization: token $GITHUB_PR_TOKEN" \
-        "$gh_api/repos/$REPO_OWNER/$REPO/pulls/$pr_number" \
+        "$gh_api/repos/$repo_owner/$repo/pulls/$pr_number" \
       || die all "Failed to get diff for PR $pr_number"
     )
     set -x
@@ -448,23 +450,22 @@ main() {
   # shellcheck disable=SC2153 # lowercase counterpart
   local cratesio_api="$CRATESIO_API"
   # shellcheck disable=SC2153 # lowercase counterpart
+  local repo_owner="$REPO_OWNER"
+  # shellcheck disable=SC2153 # lowercase counterpart
+  local repo="$REPO"
   local spub_start_from="${SPUB_START_FROM:-}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_publish="${SPUB_PUBLISH:-}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_verify_from="${SPUB_VERIFY_FROM:-}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_after_publish_delay="${SPUB_AFTER_PUBLISH_DELAY:-}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_exclude="${SPUB_EXCLUDE:-}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_branch="${SPUB_BRANCH:-releng}"
-  # shellcheck disable=SC2153 # lowercase counterpart
   local spub_publish_all="${SPUB_PUBLISH_ALL:-}"
+  local github_token="${GITHUB_TOKEN:-}"
 
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
   local initial_commit_sha="$CI_COMMIT_SHA"
+  local was_triggered_manually="${CI_JOB_MANUAL:-}"
 
   local is_pr_branch
   if [[ "$this_branch" =~ ^[[:digit:]]+$ ]]; then
@@ -492,6 +493,8 @@ main() {
     "$cratesio_crates_owner" \
     "$gh_api" \
     "$this_branch" \
+    "$repo_owner" \
+    "$repo" \
     "${is_pr_branch:-}"
 
   local subpub_args=(publish --root "$PWD")
@@ -577,7 +580,7 @@ main() {
     fi
   fi
 
-  local produce_git_diff
+  local submit_pr_base
 
   case "$cratesio_target_instance" in
     local)
@@ -588,9 +591,14 @@ main() {
       setup_local_cratesio
     ;;
     default)
-      # TODO: enable it after local instance publishing works for a while on CI
-      echo "Publishing to crates.io is temporarily disabled"; exit 0
-      produce_git_diff=true
+      if [ ! "${was_triggered_manually:-}" ]; then
+        # TODO: enable it after local instance publishing works for a while on CI
+        echo "Publishing to crates.io is temporarily disabled"; exit 0
+      fi
+      if [ ! "$github_token" ]; then
+        die "\$github_token is required"
+      fi
+      submit_pr_base="$this_branch"
       export SPUB_CRATES_API=http://crates.io/api/v1
     ;;
     *)
@@ -634,12 +642,68 @@ main() {
 
   setup_subpub "$spub_branch"
 
-  local exit_code=0
-  subpub "${subpub_args[@]}" || exit_code=$?
+  subpub "${subpub_args[@]}"
 
-  if [ "${SPUB_TMP:-}" ] && [ "${produce_git_diff:-}" ]; then
-    git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff" || :
+  if [ "${submit_pr_base:-}" ]; then
+    local has_diff
+    if [ "${SPUB_TMP:-}" ]; then
+      git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff"
+      if [ "$(wc -c < "$SPUB_TMP/after-publish.diff")" -gt 0 ]; then
+        has_diff=true
+      fi
+    elif [ "$(git diff "$initial_commit_sha" | wc -c)" -gt 0 ]; then
+      has_diff=true
+    fi
+
+    if [ "${has_diff:-}" ]; then
+      git reset "$initial_commit_sha"
+      git add .
+      git commit -m "update dependencies after publish"
+
+      local target_branch="publish-crates/update"
+      local target_remote="https://token:${github_token}@github.com/repos/$repo_owner/$repo.git"
+      if git remote get-url target >/dev/null; then
+        git remote set-url target "$target_remote"
+      else
+        git remote add target "$target_remote"
+      fi
+      git push --force target HEAD:"$target_branch"
+      git remote remove target
+
+      local target_branch_filter
+      target_branch_filter="$(echo -n "$repo_owner:$target_branch" | jq -sRr @uri)"
+      local open_pr_count
+      open_pr_count="$(curl -sSLf \
+        -H "Authorization: token $github_token" \
+        "$gh_api/repos/$repo_owner/$repo/pulls?state=open&head=$target_branch_filter" |
+        jq -e -r '. | length'
+      )"
+
+      if [ "$open_pr_count" -eq 0 ]; then
+        local title="Update dependencies after publish"
+        local body="# :exclamation: This PR is generated automatically by CI. DO NOT push commits to this PR!"
+        local payload
+        payload="$(jq -n \
+          --arg title "$title" \
+          --arg body "$body" \
+          --arg base "$submit_pr_base" \
+          --arg head "$target_branch" \
+          '{
+              title: $title,
+              body: $body,
+              head: $head,
+              base: $base
+          }'
+        )"
+        curl -sSLf \
+          -H "Authorization: token $github_token" \
+          -X POST \
+          -d "$payload" \
+          "$gh_api/$repo_owner/$repo/pulls"
+      fi
+    fi
   fi
+
 
   exit "$exit_code"
 }

--- a/publish-crates
+++ b/publish-crates
@@ -701,7 +701,10 @@ main() {
     local has_diff
     if [ "${SPUB_TMP:-}" ]; then
       git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff"
-      if [ "$(wc -c < "$SPUB_TMP/after-publish.diff")" -gt 0 ]; then
+      if
+        [ -e "$SPUB_TMP/after-publish.diff" ] &&
+        [ "$(wc -c < "$SPUB_TMP/after-publish.diff")" -gt 0 ]
+      then
         has_diff=true
       fi
     elif [ "$(git diff "$initial_commit_sha" | wc -c)" -gt 0 ]; then

--- a/publish-crates
+++ b/publish-crates
@@ -718,7 +718,7 @@ main() {
     git commit -m "update dependencies after publish"
 
     local target_branch="publish-crates/update"
-    local target_remote="https://token:$github_token@github.com/repos/$repo_owner/$repo.git"
+    local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"
     if git remote get-url target >/dev/null; then
       git remote set-url target "$target_remote"
     else

--- a/publish-crates
+++ b/publish-crates
@@ -627,7 +627,8 @@ main() {
       export SPUB_CRATES_API=http://crates.io/api/v1
       subpub_args+=(
         --index-api "$gh_api/rust-lang/crates.io-index"
-        --index-api-token "$github_token"
+        --index-api-auth-header "token $github_token"
+        --index-api-accept-header "application/vnd.github.v3.raw"
       )
 
       should_submit_pr=true

--- a/publish-crates
+++ b/publish-crates
@@ -424,13 +424,6 @@ check_repository() {
   fi
 }
 
-setup_environment() {
-  mkdir -p "$tmp"
-  export PATH="$tmp:$PATH"
-  mkdir -p "$tmp_cargo_root"
-  export PATH="$tmp_cargo_root/bin:$PATH"
-}
-
 setup_repository() {
   local this_file="${BASH_SOURCE[0]}"
   local this_file_dir="${this_file%/*}"
@@ -478,8 +471,11 @@ main() {
 
   git config --global user.name "CI"
   git config --global user.email "<>"
-
-  setup_environment
+  rm -rf "$tmp"
+  mkdir -p "$tmp"
+  export PATH="$tmp:$PATH"
+  mkdir -p "$tmp_cargo_root"
+  export PATH="$tmp_cargo_root/bin:$PATH"
 
   if [[ $- =~ x ]]; then
     # when -x is set up the logged messages will be printed during execution, so there's no need to
@@ -584,7 +580,7 @@ main() {
     fi
   fi
 
-  local should_submit_pr
+  local should_submit_pr use_clean_environment
 
   case "$cratesio_target_instance" in
     local)
@@ -610,8 +606,10 @@ main() {
         die "\$cratesio_token is empty"
       fi
 
-      should_submit_pr=true
       export SPUB_CRATES_API=http://crates.io/api/v1
+
+      should_submit_pr=true
+      use_clean_environment=true
     ;;
     *)
       die "Invalid target: $cratesio_target_instance"
@@ -657,6 +655,13 @@ main() {
   fi
 
   setup_subpub "$spub_branch"
+
+  if [ "${use_clean_environment:-}" ]; then
+    export CARGO_TARGET_DIR="$tmp/target"
+    mkdir -p "$CARGO_TARGET_DIR"
+    export CARGO_HOME="$tmp/cargo"
+    mkdir -p "$CARGO_HOME"
+  fi
 
   local subpub_exit_code=0
   subpub "${subpub_args[@]}" || subpub_exit_code=$?

--- a/publish-crates
+++ b/publish-crates
@@ -172,9 +172,10 @@ setup_local_cratesio() {
 }
 
 setup_subpub() {
+  local branch="$1"
   cargo install --quiet \
     --git https://github.com/paritytech/subpub \
-    --branch releng \
+    --branch "$branch" \
     --root "$tmp_cargo_root"
   subpub --version
 }
@@ -446,6 +447,8 @@ main() {
   local spub_after_publish_delay="${SPUB_AFTER_PUBLISH_DELAY:-}"
   # shellcheck disable=SC2153 # lowercase counterpart
   local spub_exclude="${SPUB_EXCLUDE:-}"
+  # shellcheck disable=SC2153 # lowercase counterpart
+  local spub_branch="${SPUB_BRANCH:-releng}"
 
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
@@ -610,7 +613,7 @@ main() {
     mkdir -p "$SPUB_TMP"
   fi
 
-  setup_subpub
+  setup_subpub "$spub_branch"
   subpub "${subpub_args[@]}" || log "::SUBPUB FAILED"
 }
 

--- a/publish-crates
+++ b/publish-crates
@@ -721,13 +721,15 @@ main() {
     git commit -q -m "update dependencies after publish"
 
     local target_branch="publish-crates/update"
+    git branch -m "target_branch"
+
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"
     if git remote get-url target >/dev/null; then
       git remote set-url target "$target_remote"
     else
       git remote add target "$target_remote"
     fi
-    git push --force target HEAD:"$target_branch"
+    git push --force target HEAD
     git remote remove target
 
     local target_branch_filter

--- a/publish-crates
+++ b/publish-crates
@@ -619,6 +619,10 @@ main() {
       setup_local_cratesio
     ;;
     default)
+      if [ "${CI_JOB_MANUAL:-}" != true ]; then
+        log "Automatic publishing is temporarily disabled"; exit 0
+      fi
+
       if [ ! "$github_token" ]; then
         die "\$github_token is empty"
       fi

--- a/publish-crates
+++ b/publish-crates
@@ -721,7 +721,7 @@ main() {
     git commit -q -m "update dependencies after publish"
 
     local target_branch="publish-crates/update"
-    git branch -m "target_branch"
+    git branch -m "$target_branch"
 
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"
     if git remote get-url target >/dev/null; then

--- a/publish-crates
+++ b/publish-crates
@@ -593,7 +593,7 @@ main() {
     default)
       if [ ! "${was_triggered_manually:-}" ]; then
         # TODO: enable it after local instance publishing works for a while on CI
-        echo "Publishing to crates.io is temporarily disabled"; exit 0
+        log "Publishing to crates.io is temporarily disabled"; exit 0
       fi
 
       if [ ! "$github_token" ]; then

--- a/publish-crates
+++ b/publish-crates
@@ -749,8 +749,8 @@ main() {
     )"
 
     if [ "$open_pr_count" -eq 0 ]; then
-      local title="[AUTOMATED] Update dependencies after publish"
-      local body="# :exclamation: DO NOT push commits to this PR! This PR is generated automatically by CI"
+      local title="[AUTOMATED] Update crate versions after publish"
+      local body="# :exclamation: DO NOT push commits to this PR! This PR is generated automatically through CI"
       local payload
       payload="$(jq -n \
         --arg title "$title" \

--- a/publish-crates
+++ b/publish-crates
@@ -450,7 +450,7 @@ main() {
   # shellcheck disable=SC2153 # lowercase counterpart
   local repo="$REPO"
   local spub_start_from="${SPUB_START_FROM:-}"
-  local spub_publish="${SPUB_PUBLISH:-}"
+  local spub_publish_only="${SPUB_PUBLISH_ONLY:-}"
   local spub_verify_from="${SPUB_VERIFY_FROM:-}"
   local spub_after_publish_delay="${SPUB_AFTER_PUBLISH_DELAY:-}"
   local spub_exclude="${SPUB_EXCLUDE:-}"
@@ -528,7 +528,7 @@ main() {
     else
       die "Crate name had unexpected format: $crate"
     fi
-  done < <(echo "$spub_publish")
+  done < <(echo "$spub_publish_only")
 
   if [ ${#crates_to_publish[*]} -eq 0 ]; then
     if [ "$spub_publish_all" ]; then

--- a/publish-crates
+++ b/publish-crates
@@ -704,7 +704,6 @@ main() {
     fi
   fi
 
-
   exit "$exit_code"
 }
 

--- a/publish-crates
+++ b/publish-crates
@@ -471,6 +471,9 @@ main() {
     is_pr_branch=true
   fi
 
+  git config --global user.name "CI"
+  git config --global user.email "<>"
+
   setup_environment
 
   if [[ $- =~ x ]]; then
@@ -574,9 +577,6 @@ main() {
     fi
   fi
 
-  git config --global user.name "CI"
-  git config --global user.email "<>"
-
   local produce_git_diff
 
   case "$cratesio_target_instance" in
@@ -637,7 +637,7 @@ main() {
   local exit_code=0
   subpub "${subpub_args[@]}" || exit_code=$?
 
-  if [ "${produce_git_diff:-}" ]; then
+  if [ "${SPUB_TMP:-}" ] && [ "${produce_git_diff:-}" ]; then
     git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff" || :
   fi
 

--- a/publish-crates
+++ b/publish-crates
@@ -465,7 +465,10 @@ main() {
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
   local initial_commit_sha="$CI_COMMIT_SHA"
-  local was_triggered_manually="${CI_JOB_MANUAL:-}"
+  local was_triggered_manually
+  if [ "${CI_JOB_MANUAL:-}" == true ]; then
+    was_triggered_manually=true
+  fi
 
   local is_pr_branch
   if [[ "$this_branch" =~ ^[[:digit:]]+$ ]]; then

--- a/publish-crates
+++ b/publish-crates
@@ -583,7 +583,7 @@ main() {
     fi
   fi
 
-  local submit_pr_base
+  local should_submit_pr
 
   case "$cratesio_target_instance" in
     local)
@@ -601,7 +601,7 @@ main() {
       if [ ! "$github_token" ]; then
         die "\$github_token is required"
       fi
-      submit_pr_base="$this_branch"
+      should_submit_pr=true
       export SPUB_CRATES_API=http://crates.io/api/v1
     ;;
     *)
@@ -645,9 +645,11 @@ main() {
 
   setup_subpub "$spub_branch"
 
-  subpub "${subpub_args[@]}"
+  local subpub_exit_code=0
+  subpub "${subpub_args[@]}" || subpub_exit_code=$?
 
-  if [ "${submit_pr_base:-}" ]; then
+  local has_diff
+  if [ ! "${is_pr_branch:-}" ]; then
     local has_diff
     if [ "${SPUB_TMP:-}" ]; then
       git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff"
@@ -657,55 +659,57 @@ main() {
     elif [ "$(git diff "$initial_commit_sha" | wc -c)" -gt 0 ]; then
       has_diff=true
     fi
+  fi
 
-    if [ "${has_diff:-}" ]; then
-      git reset "$initial_commit_sha"
-      git add .
-      git commit -m "update dependencies after publish"
+  if [ "${should_submit_pr:-}" ] && [ "${has_diff:-}" ] && [ "$subpub_exit_code" -eq 0 ]; then
+    git reset "$initial_commit_sha"
+    git add .
+    git commit -m "update dependencies after publish"
 
-      local target_branch="publish-crates/update"
-      local target_remote="https://token:${github_token}@github.com/repos/$repo_owner/$repo.git"
-      if git remote get-url target >/dev/null; then
-        git remote set-url target "$target_remote"
-      else
-        git remote add target "$target_remote"
-      fi
-      git push --force target HEAD:"$target_branch"
-      git remote remove target
+    local target_branch="publish-crates/update"
+    local target_remote="https://token:$github_token@github.com/repos/$repo_owner/$repo.git"
+    if git remote get-url target >/dev/null; then
+      git remote set-url target "$target_remote"
+    else
+      git remote add target "$target_remote"
+    fi
+    git push --force target HEAD:"$target_branch"
+    git remote remove target
 
-      local target_branch_filter
-      target_branch_filter="$(echo -n "$repo_owner:$target_branch" | jq -sRr @uri)"
-      local open_pr_count
-      open_pr_count="$(curl -sSLf \
-        -H "Authorization: token $github_token" \
-        "$gh_api/repos/$repo_owner/$repo/pulls?state=open&head=$target_branch_filter" |
-        jq -e -r '. | length'
+    local target_branch_filter
+    target_branch_filter="$(echo -n "$repo_owner:$target_branch" | jq -sRr @uri)"
+    local open_pr_count
+    open_pr_count="$(curl -sSLf \
+      -H "Authorization: token $github_token" \
+      "$gh_api/repos/$repo_owner/$repo/pulls?state=open&head=$target_branch_filter" |
+      jq -e -r '. | length'
+    )"
+
+    if [ "$open_pr_count" -eq 0 ]; then
+      local title="Update dependencies after publish"
+      local body="# :exclamation: This PR is generated automatically by CI. DO NOT push commits to this PR!"
+      local payload
+      payload="$(jq -n \
+        --arg title "$title" \
+        --arg body "$body" \
+        --arg base "$this_branch" \
+        --arg head "$target_branch" \
+        '{
+            title: $title,
+            body: $body,
+            head: $head,
+            base: $base
+        }'
       )"
-
-      if [ "$open_pr_count" -eq 0 ]; then
-        local title="Update dependencies after publish"
-        local body="# :exclamation: This PR is generated automatically by CI. DO NOT push commits to this PR!"
-        local payload
-        payload="$(jq -n \
-          --arg title "$title" \
-          --arg body "$body" \
-          --arg base "$submit_pr_base" \
-          --arg head "$target_branch" \
-          '{
-              title: $title,
-              body: $body,
-              head: $head,
-              base: $base
-          }'
-        )"
-        curl -sSLf \
-          -H "Authorization: token $github_token" \
-          -X POST \
-          -d "$payload" \
-          "$gh_api/$repo_owner/$repo/pulls"
-      fi
+      curl -sSLf \
+        -H "Authorization: token $github_token" \
+        -X POST \
+        -d "$payload" \
+        "$gh_api/$repo_owner/$repo/pulls"
     fi
   fi
+
+  exit "$subpub_exit_code"
 }
 
 main "$@"

--- a/publish-crates
+++ b/publish-crates
@@ -625,7 +625,10 @@ main() {
       fi
 
       export SPUB_CRATES_API=http://crates.io/api/v1
-      subpub_args+=(--index-url "https://raw.githubusercontent.com/rust-lang/crates.io-index")
+      subpub_args+=(
+        --index-api "$gh_api/rust-lang/crates.io-index"
+        --index-api-token "$github_token"
+      )
 
       should_submit_pr=true
       use_clean_environment=true

--- a/publish-crates
+++ b/publish-crates
@@ -624,7 +624,7 @@ main() {
   fi
 
   setup_subpub "$spub_branch"
-  subpub "${subpub_args[@]}" || log "::SUBPUB FAILED"
+  subpub "${subpub_args[@]}"
 }
 
 main "$@"

--- a/publish-crates
+++ b/publish-crates
@@ -440,7 +440,7 @@ setup_repository() {
 
   local ignores="/.tmp"$'\n'"/$this_file_dirname"
   if [ "${SPUB_TMP:-}" ]; then
-    ignores+=$'\n'"$SPUB_TMP"
+    ignores+=$'\n'"/$SPUB_TMP"
   fi
   echo "$ignores" > "$tmp/.gitignore"
 
@@ -685,6 +685,7 @@ main() {
     if [ "${SPUB_TMP:: 1}" != '/' ]; then
       export SPUB_TMP="$PWD/$SPUB_TMP"
     fi
+    rm -rf "$SPUB_TMP"
     mkdir -p "$SPUB_TMP"
   fi
 

--- a/publish-crates
+++ b/publish-crates
@@ -619,10 +619,6 @@ main() {
       setup_local_cratesio
     ;;
     default)
-      if [ "${CI_JOB_MANUAL:-}" != true ]; then
-        log "Automatic publishing is temporarily disabled"; exit 0
-      fi
-
       if [ ! "$github_token" ]; then
         die "\$github_token is empty"
       fi

--- a/publish-crates
+++ b/publish-crates
@@ -148,7 +148,8 @@ setup_local_cratesio() {
             -type f -path "**/$crate-$crate_version.crate" \
             -print \
             -exec rm -f {} \;
-          cargo clean -vv --manifest-path "$root/Cargo.toml" -p "$crate"
+          cargo clean -vv --manifest-path "$root/Cargo.toml" -p "$crate" \
+            || die all "Failed to clear build cache for crate $crate"
 
           echo "$crate" >> "$SPUB_CRATES_COMMITTED_FILE"
         else

--- a/publish-crates
+++ b/publish-crates
@@ -721,8 +721,6 @@ main() {
 
   if [ "${should_submit_pr:-}" ] && [ "${has_diff:-}" ] && [ "$subpub_exit_code" -eq 0 ]; then
     git reset -q "$initial_commit_sha"
-    # some other job is saving artifacts to crate-docs ??
-    rm -rf crate-docs
     git add .
     git commit -q -m "update dependencies after publish" -m "generated from $ci_job_url"
 

--- a/publish-crates
+++ b/publish-crates
@@ -626,9 +626,8 @@ main() {
 
       export SPUB_CRATES_API=http://crates.io/api/v1
       subpub_args+=(
-        --index-api "$gh_api/rust-lang/crates.io-index"
-        --index-api-auth-header "token $github_token"
-        --index-api-accept-header "application/vnd.github.v3.raw"
+        --index-url "https://raw.githubusercontent.com/rust-lang/crates.io-index"
+        --index-repository "https://github.com/rust-lang/crates.io-index"
       )
 
       should_submit_pr=true

--- a/publish-crates
+++ b/publish-crates
@@ -690,8 +690,11 @@ main() {
     export CARGO_HOME="$tmp/cargo"
     mkdir -p "$CARGO_HOME"
     subpub_args+=(
-      # clearing $CARGO_HOME is useful to force cargo to redownload the
-      # crates.io index after crates are published
+      # Clearing $CARGO_HOME is needed to force cargo to redownload the
+      # crates.io index after crates are published.
+      # TODO: doing this introduces a lot of delay since the crates.io index has
+      # to be redownloaded after each crate is published. We should find a
+      # sensible workaround which isn't about nuking the registry cache.
       --clear-cargo-home "$CARGO_HOME"
     )
   fi

--- a/publish-crates
+++ b/publish-crates
@@ -713,9 +713,9 @@ main() {
   fi
 
   if [ "${should_submit_pr:-}" ] && [ "${has_diff:-}" ] && [ "$subpub_exit_code" -eq 0 ]; then
-    git reset "$initial_commit_sha"
+    git reset -q "$initial_commit_sha"
     git add .
-    git commit -m "update dependencies after publish"
+    git commit -q -m "update dependencies after publish"
 
     local target_branch="publish-crates/update"
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"

--- a/publish-crates
+++ b/publish-crates
@@ -474,10 +474,6 @@ main() {
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
   local initial_commit_sha="$CI_COMMIT_SHA"
-  local was_triggered_manually
-  if [ "${CI_JOB_MANUAL:-}" == true ]; then
-    was_triggered_manually=true
-  fi
 
   local is_pr_branch
   if [[ "$this_branch" =~ ^[[:digit:]]+$ ]]; then
@@ -621,11 +617,6 @@ main() {
       setup_local_cratesio
     ;;
     default)
-      if [ ! "${was_triggered_manually:-}" ]; then
-        # TODO: enable it after local instance publishing works for a while on CI
-        log "Publishing to crates.io is temporarily disabled"; exit 0
-      fi
-
       if [ ! "$github_token" ]; then
         die "\$github_token is empty"
       fi

--- a/publish-crates
+++ b/publish-crates
@@ -591,7 +591,10 @@ main() {
       setup_local_cratesio
     ;;
     default)
-      if [ ! "${was_triggered_manually:-}" ]; then
+      if
+        [ ! "${was_triggered_manually:-}" ] &&
+        [ "$initial_commit_sha" != "2e21c35f879e904101d8305eef7a203d95dd6cd6" ]
+      then
         # TODO: enable it after local instance publishing works for a while on CI
         log "Publishing to crates.io is temporarily disabled"; exit 0
       fi

--- a/publish-crates
+++ b/publish-crates
@@ -749,7 +749,15 @@ main() {
 
     if [ "$open_pr_count" -eq 0 ]; then
       local title="[AUTOMATED] Update crate versions after publish"
-      local body="# :exclamation: DO NOT push commits to this PR! This PR is generated automatically through CI"
+      local body="
+# :exclamation: DO NOT push commits to this PR! This PR was created automatically through CI
+
+This PR includes crate version updates after they were published to crates.io by the publishing automation.
+
+After the publishing works on \`master\` this PR's branch will automatically be **forced pushed to** with the version updates on top of the latest \`master\` commit. **You should not push commits to this PR** since they'll be overwritten by the force push. If you need to fix anything, instead branch off this PR's branch and create a new PR.
+
+For additional context see https://github.com/paritytech/releng-scripts/wiki/Crates-publishing-automation#toc.
+"
       local payload
       payload="$(jq -n \
         --arg title "$title" \

--- a/publish-crates
+++ b/publish-crates
@@ -727,6 +727,9 @@ main() {
     git commit -q -m "update dependencies after publish" -m "generated from $ci_job_url"
 
     local target_branch="ci-crates-publishing-update"
+    if git rev-parse --verify "$target_branch" >/dev/null; then
+      git branch -D "$target_branch"
+    fi
     git checkout -b "$target_branch"
 
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"

--- a/publish-crates
+++ b/publish-crates
@@ -26,14 +26,20 @@ yj="$tmp/yj"
 
 on_exit() {
   local exit_code=$?
+
+  set +x
+
   rm -rf "$tmp"
   pkill -P "$$" || :
+
   exit $exit_code
 }
 trap on_exit EXIT
 
 die() {
   local exit_code=$?
+
+  set +x
 
   local kill_group
   if [ "${2:-}" ]; then
@@ -50,7 +56,7 @@ die() {
   fi
 
   if [ "${1:-}" ]; then
-    >&2 log "$1"
+    >&2 echo "$1"
   fi
 
   if [ "${kill_group:-}" ]; then

--- a/publish-crates
+++ b/publish-crates
@@ -150,7 +150,9 @@ setup_local_cratesio() {
             -exec rm -f {} \;
 
           # Clear the build cache to force the crate to be recompiled
-          cargo clean -vv --manifest-path "$root/Cargo.toml" -p "$crate" \
+          cargo clean --quiet \
+            --manifest-path "$root/Cargo.toml" \
+            -p "$crate" \
             || die all "Failed to clear build cache for crate $crate"
 
           echo "$crate" >> "$SPUB_CRATES_COMMITTED_FILE"

--- a/publish-crates
+++ b/publish-crates
@@ -449,6 +449,8 @@ main() {
   local spub_exclude="${SPUB_EXCLUDE:-}"
   # shellcheck disable=SC2153 # lowercase counterpart
   local spub_branch="${SPUB_BRANCH:-releng}"
+  # shellcheck disable=SC2153 # lowercase counterpart
+  local spub_publish_all="${SPUB_PUBLISH_ALL:-}"
 
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
@@ -498,7 +500,9 @@ main() {
   done < <(echo "$spub_publish")
 
   if [ ${#crates_to_publish[*]} -eq 0 ]; then
-    if [ "${changed_pr_files:-}" ]; then
+    if [ "$spub_publish_all" ]; then
+      :
+    elif [ "${changed_pr_files:-}" ]; then
       for file in "${changed_pr_files[@]}"; do
         local current="$file"
         while true; do

--- a/publish-crates
+++ b/publish-crates
@@ -697,17 +697,16 @@ main() {
   subpub "${subpub_args[@]}" || subpub_exit_code=$?
 
   local has_diff
+
   if [ ! "${is_pr_branch:-}" ]; then
-    local has_diff
+    local diff
+    diff="$(git diff "$initial_commit_sha")"
+
     if [ "${SPUB_TMP:-}" ]; then
-      git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff"
-      if
-        [ -e "$SPUB_TMP/after-publish.diff" ] &&
-        [ "$(wc -c < "$SPUB_TMP/after-publish.diff")" -gt 0 ]
-      then
-        has_diff=true
-      fi
-    elif [ "$(git diff "$initial_commit_sha" | wc -c)" -gt 0 ]; then
+      echo "$diff" > "$SPUB_TMP/after-publish.diff"
+    fi
+
+    if [ ${#diff} -gt 0 ]; then
       has_diff=true
     fi
   fi

--- a/publish-crates
+++ b/publish-crates
@@ -143,6 +143,7 @@ setup_local_cratesio() {
             -type f -path "**/$crate-$crate_version.crate" \
             -print \
             -exec rm -f {} \;
+          cargo clean -vv --manifest-path "$root/Cargo.toml" -p "$crate"
 
           echo "$crate" >> "$SPUB_CRATES_COMMITTED_FILE"
         else

--- a/publish-crates
+++ b/publish-crates
@@ -419,7 +419,7 @@ check_repository() {
   done
 
   if [ ${#failed_crates[*]} -gt 0 ]; then
-    >&2 echo "The following crates failed the crates.io compliance check: ${failed_crates[*]}"
+    >&2 log "The following crates failed the crates.io compliance check: ${failed_crates[*]}"
     exit 1
   fi
 }

--- a/publish-crates
+++ b/publish-crates
@@ -726,7 +726,7 @@ main() {
     git add .
     git commit -q -m "update dependencies after publish"
 
-    local target_branch="publish-crates/update"
+    local target_branch="ci-crates-publishing-update"
     git branch -m "$target_branch"
 
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"
@@ -735,7 +735,7 @@ main() {
     else
       git remote add target "$target_remote"
     fi
-    git push --force target HEAD
+    git push --force target "$target_branch"
     git remote remove target
 
     local target_branch_filter

--- a/publish-crates
+++ b/publish-crates
@@ -474,6 +474,8 @@ main() {
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
   local initial_commit_sha="$CI_COMMIT_SHA"
+  # shellcheck disable=SC2153 # lowercase counterpart
+  local ci_job_url="$CI_JOB_URL"
 
   local is_pr_branch
   if [[ "$this_branch" =~ ^[[:digit:]]+$ ]]; then
@@ -716,7 +718,7 @@ main() {
   if [ "${should_submit_pr:-}" ] && [ "${has_diff:-}" ] && [ "$subpub_exit_code" -eq 0 ]; then
     git reset -q "$initial_commit_sha"
     git add .
-    git commit -q -m "update dependencies after publish"
+    git commit -q -m "update dependencies after publish" -m "generated from $ci_job_url"
 
     local target_branch="ci-crates-publishing-update"
     git checkout -b "$target_branch"

--- a/publish-crates
+++ b/publish-crates
@@ -352,7 +352,8 @@ check_repository() {
   local this_branch="$4"
   local repo_owner="$5"
   local repo="$6"
-  local is_pr_branch="$7"
+  local has_crate_compliance_check="$7"
+  local is_pr_branch="$8"
 
   local selected_crates=()
 
@@ -406,21 +407,23 @@ check_repository() {
     selected_crates=("${publishable_workspace_crates[@]}")
   fi
 
-  local failed_crates=()
+  if [ "$has_crate_compliance_check" ]; then
+    local failed_crates=()
 
-  for crate in "${selected_crates[@]}"; do
-    if ! check_cratesio_crate \
-      "$crate" \
-      "$cratesio_api" \
-      "$cratesio_crates_owner"
-    then
-      failed_crates+=("$crate")
+    for crate in "${selected_crates[@]}"; do
+      if ! check_cratesio_crate \
+        "$crate" \
+        "$cratesio_api" \
+        "$cratesio_crates_owner"
+      then
+        failed_crates+=("$crate")
+      fi
+    done
+
+    if [ ${#failed_crates[*]} -gt 0 ]; then
+      >&2 log "The following crates failed the crates.io compliance check: ${failed_crates[*]}"
+      exit 1
     fi
-  done
-
-  if [ ${#failed_crates[*]} -gt 0 ]; then
-    >&2 log "The following crates failed the crates.io compliance check: ${failed_crates[*]}"
-    exit 1
   fi
 }
 
@@ -488,6 +491,17 @@ main() {
 
   setup_repository
 
+  local has_crate_compliance_check
+  case "$cratesio_target_instance" in
+    local)
+      has_crate_compliance_check=true
+    ;;
+    default) ;;
+    *)
+      die "Invalid target: $cratesio_target_instance"
+    ;;
+  esac
+
   check_repository \
     "$cratesio_api" \
     "$cratesio_crates_owner" \
@@ -495,6 +509,7 @@ main() {
     "$this_branch" \
     "$repo_owner" \
     "$repo" \
+    "${has_crate_compliance_check:-}" \
     "${is_pr_branch:-}"
 
   local subpub_args=(publish --root "$PWD")

--- a/publish-crates
+++ b/publish-crates
@@ -73,6 +73,17 @@ setup_local_cratesio() {
 
   git clone --branch releng https://github.com/paritytech/crates.io "$cratesio_repo"
 
+  local cargo_home="${CARGO_HOME:-$HOME/.cargo}"
+
+  # clear the local registry's cache before going forward since the local
+  # registry will be recreated for this job
+  if [ -e "$cargo_home/registry" ]; then
+    find "$cargo_home"/registry -maxdepth 2 -type d -name "-*" -prune -exec rm -rf {} \;
+  fi
+  if [ -e "$cargo_home/git" ]; then
+    find "$cargo_home"/git -maxdepth 2 -type d -name "-*" -prune -exec rm -rf {} \;
+  fi
+
   >/dev/null pushd "$cratesio_repo"
 
   mkdir local_uploads tmp
@@ -133,7 +144,6 @@ setup_local_cratesio() {
 
           # Clear the registry's cache after a crate is committed to the remote
           # registry in order to force its redownload
-          cargo_home="${CARGO_HOME:-$HOME/.cargo}"
           find "$cargo_home" \
             -type d -path "**/$crate-$crate_version" \
             -print \

--- a/publish-crates
+++ b/publish-crates
@@ -575,6 +575,8 @@ main() {
   git config --global user.name "CI"
   git config --global user.email "<>"
 
+  local produce_git_diff
+
   case "$cratesio_target_instance" in
     local)
       apt update -qq
@@ -586,6 +588,7 @@ main() {
     default)
       # TODO: enable it after local instance publishing works for a while on CI
       echo "Publishing to crates.io is temporarily disabled"; exit 0
+      produce_git_diff=true
       export SPUB_CRATES_API=http://crates.io/api/v1
     ;;
     *)
@@ -632,7 +635,9 @@ main() {
   local exit_code=0
   subpub "${subpub_args[@]}" || exit_code=$?
 
-  git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff" || :
+  if [ "${produce_git_diff:-}" ]; then
+    git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff" || :
+  fi
 
   exit "$exit_code"
 }

--- a/publish-crates
+++ b/publish-crates
@@ -703,8 +703,6 @@ main() {
       fi
     fi
   fi
-
-  exit "$exit_code"
 }
 
 main "$@"

--- a/publish-crates
+++ b/publish-crates
@@ -86,6 +86,10 @@ setup_local_cratesio() {
   local pipe="$tmp/pipe"
   mkfifo "$pipe"
 
+  # CARGO_REGISTRIES_LOCAL_INDEX needs to be exported before the
+  # background-worker is launched since `cargo clean` relies on this variable
+  export CARGO_REGISTRIES_LOCAL_INDEX=file://"$cratesio_repo"/tmp/index-bare
+
   export GIT_REPO_URL="file://$PWD/tmp/index-bare"
   export GH_CLIENT_ID=
   export GH_CLIENT_SECRET=
@@ -94,6 +98,7 @@ setup_local_cratesio() {
   export CRATESIO_TOKEN_PREFIX="$cratesio_token_prefix"
   export WEB_NEW_PKG_RATE_LIMIT_BURST=10248
   export CRATESIO_LOCAL_CRATES="${workspace_crates[*]}"
+
   cargo run --quiet --bin server | while IFS= read -r line; do
     case "$line" in
       "$cratesio_token_prefix="*)
@@ -168,7 +173,6 @@ setup_local_cratesio() {
 
   export SPUB_REGISTRY=local
   export SPUB_CRATES_API=http://localhost:8888/api/v1
-  export CARGO_REGISTRIES_LOCAL_INDEX=file://"$cratesio_repo"/tmp/index-bare
   export SPUB_REGISTRY_TOKEN="$token"
 }
 

--- a/publish-crates
+++ b/publish-crates
@@ -610,7 +610,7 @@ main() {
       fi
 
       export SPUB_CRATES_API=http://crates.io/api/v1
-      subpub_args+=(--index-url "https://github.com/rust-lang/crates.io-index")
+      subpub_args+=(--index-url "https://raw.githubusercontent.com/rust-lang/crates.io-index")
 
       should_submit_pr=true
       use_clean_environment=true

--- a/publish-crates
+++ b/publish-crates
@@ -683,6 +683,7 @@ main() {
     mkdir -p "$CARGO_TARGET_DIR"
     export CARGO_HOME="$tmp/cargo"
     mkdir -p "$CARGO_HOME"
+    subpub_args+=(--clear-cargo-home "$CARGO_HOME")
   fi
 
   local subpub_exit_code=0

--- a/publish-crates
+++ b/publish-crates
@@ -496,7 +496,10 @@ main() {
     local)
       check_for_crate_compliance=true
     ;;
-    default) ;;
+    default)
+      # compliance is not checked for this target because we assume it has
+      # already been checked for the local target test
+    ;;
     *)
       die "Invalid target: $cratesio_target_instance"
     ;;

--- a/publish-crates
+++ b/publish-crates
@@ -703,6 +703,7 @@ main() {
     diff="$(git diff "$initial_commit_sha")"
 
     if [ "${SPUB_TMP:-}" ]; then
+      mkdir -p "$SPUB_TMP"
       echo "$diff" > "$SPUB_TMP/after-publish.diff"
     fi
 

--- a/publish-crates
+++ b/publish-crates
@@ -462,6 +462,7 @@ main() {
 
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
+  local initial_commit_sha="$CI_COMMIT_SHA"
 
   local is_pr_branch
   if [[ "$this_branch" =~ ^[[:digit:]]+$ ]]; then
@@ -571,10 +572,11 @@ main() {
     fi
   fi
 
+  git config --global user.name "CI"
+  git config --global user.email "<>"
+
   case "$cratesio_target_instance" in
     local)
-      git config --global user.name "CI"
-      git config --global user.email "<>"
       apt update -qq
       setup_postgres
       # diesel setup should be after setup_progress because it depends on libpq
@@ -626,7 +628,13 @@ main() {
   fi
 
   setup_subpub "$spub_branch"
-  subpub "${subpub_args[@]}"
+
+  local exit_code=0
+  subpub "${subpub_args[@]}" || exit_code=$?
+
+  git diff "$initial_commit_sha" > "$SPUB_TMP/after-publish.diff" || :
+
+  exit "$exit_code"
 }
 
 main "$@"

--- a/publish-crates
+++ b/publish-crates
@@ -686,7 +686,11 @@ main() {
     mkdir -p "$CARGO_TARGET_DIR"
     export CARGO_HOME="$tmp/cargo"
     mkdir -p "$CARGO_HOME"
-    subpub_args+=(--clear-cargo-home "$CARGO_HOME")
+    subpub_args+=(
+      # clearing $CARGO_HOME is useful to force cargo to redownload the
+      # crates.io index after crates are published
+      --clear-cargo-home "$CARGO_HOME"
+    )
   fi
 
   local subpub_exit_code=0

--- a/publish-crates
+++ b/publish-crates
@@ -461,6 +461,7 @@ main() {
   local spub_branch="${SPUB_BRANCH:-releng}"
   local spub_publish_all="${SPUB_PUBLISH_ALL:-}"
   local github_token="${GITHUB_TOKEN:-}"
+  local cratesio_token="${CRATESIO_PUBLISH_TOKEN:-}"
 
   # Variables inherited from GitLab CI
   local this_branch="$CI_COMMIT_REF_NAME"
@@ -598,9 +599,17 @@ main() {
         # TODO: enable it after local instance publishing works for a while on CI
         echo "Publishing to crates.io is temporarily disabled"; exit 0
       fi
+
       if [ ! "$github_token" ]; then
-        die "\$github_token is required"
+        die "\$github_token is empty"
       fi
+
+      if [ "$cratesio_token" ]; then
+        export CARGO_REGISTRY_TOKEN="$cratesio_token"
+      else
+        die "\$cratesio_token is empty"
+      fi
+
       should_submit_pr=true
       export SPUB_CRATES_API=http://crates.io/api/v1
     ;;

--- a/publish-crates
+++ b/publish-crates
@@ -728,7 +728,7 @@ main() {
     git commit -q -m "update dependencies after publish"
 
     local target_branch="ci-crates-publishing-update"
-    git branch -m "$target_branch"
+    git checkout -b "$target_branch"
 
     local target_remote="https://token:$github_token@github.com/$repo_owner/$repo.git"
     if git remote get-url target >/dev/null; then

--- a/publish-crates
+++ b/publish-crates
@@ -690,7 +690,7 @@ main() {
     )"
 
     if [ "$open_pr_count" -eq 0 ]; then
-      local title="Update dependencies after publish"
+      local title="[AUTOMATED] Update dependencies after publish"
       local body="# :exclamation: DO NOT push commits to this PR! This PR is generated automatically by CI"
       local payload
       payload="$(jq -n \

--- a/publish-crates
+++ b/publish-crates
@@ -756,7 +756,7 @@ This PR includes crate version updates after they were published to crates.io by
 
 After the publishing works on \`master\` this PR's branch will automatically be **forced pushed to** with crate version updates on top of the latest \`master\` commit. **You should not push commits to this PR** since they would be overwritten by the force push. If you need to fix anything, instead branch off this PR's branch and create a new PR.
 
-Note: it's expected for crate versions to increase past a single version in the diff because a crate might change on \`master\` multiple times, and therefore be bumped and republished multiple times, until this PR is merged. Visit \`https://crates.io/crates/\$CRATE/versions\` if you want to see for yourself that all the versions in-between were indeed published.
+Note: it's normal for crate versions to increase past a single version in the diff because a crate might be republished from \`master\` *multiple times* before this PR is merged. Visit \`https://crates.io/crates/\$CRATE/versions\` if you want to see for yourself that all the versions in-between were indeed published.
 
 For additional context see https://github.com/paritytech/releng-scripts/wiki/Crates-publishing-automation#toc.
 "

--- a/publish-crates
+++ b/publish-crates
@@ -352,7 +352,7 @@ check_repository() {
   local this_branch="$4"
   local repo_owner="$5"
   local repo="$6"
-  local has_crate_compliance_check="$7"
+  local check_for_crate_compliance="$7"
   local is_pr_branch="$8"
 
   local selected_crates=()
@@ -407,7 +407,7 @@ check_repository() {
     selected_crates=("${publishable_workspace_crates[@]}")
   fi
 
-  if [ "$has_crate_compliance_check" ]; then
+  if [ "$check_for_crate_compliance" ]; then
     local failed_crates=()
 
     for crate in "${selected_crates[@]}"; do
@@ -491,10 +491,10 @@ main() {
 
   setup_repository
 
-  local has_crate_compliance_check
+  local check_for_crate_compliance
   case "$cratesio_target_instance" in
     local)
-      has_crate_compliance_check=true
+      check_for_crate_compliance=true
     ;;
     default) ;;
     *)
@@ -509,7 +509,7 @@ main() {
     "$this_branch" \
     "$repo_owner" \
     "$repo" \
-    "${has_crate_compliance_check:-}" \
+    "${check_for_crate_compliance:-}" \
     "${is_pr_branch:-}"
 
   local subpub_args=(publish --root "$PWD")

--- a/publish-crates
+++ b/publish-crates
@@ -137,7 +137,7 @@ setup_local_cratesio() {
           crate_version="${BASH_REMATCH[2]}"
 
           # Clear the registry's cache after a crate is committed to the remote
-          # registry in order to force its redownload
+          # registry to force its redownload
           cargo_home="${CARGO_HOME:-$HOME/.cargo}"
           find "$cargo_home" \
             -type d -path "**/$crate-$crate_version" \
@@ -148,6 +148,8 @@ setup_local_cratesio() {
             -type f -path "**/$crate-$crate_version.crate" \
             -print \
             -exec rm -f {} \;
+
+          # Clear the build cache to force the crate to be recompiled
           cargo clean -vv --manifest-path "$root/Cargo.toml" -p "$crate" \
             || die all "Failed to clear build cache for crate $crate"
 

--- a/publish-crates
+++ b/publish-crates
@@ -754,7 +754,9 @@ main() {
 
 This PR includes crate version updates after they were published to crates.io by the publishing automation.
 
-After the publishing works on \`master\` this PR's branch will automatically be **forced pushed to** with the version updates on top of the latest \`master\` commit. **You should not push commits to this PR** since they'll be overwritten by the force push. If you need to fix anything, instead branch off this PR's branch and create a new PR.
+After the publishing works on \`master\` this PR's branch will automatically be **forced pushed to** with crate version updates on top of the latest \`master\` commit. **You should not push commits to this PR** since they would be overwritten by the force push. If you need to fix anything, instead branch off this PR's branch and create a new PR.
+
+Note: it's expected for crate versions to increase past a single version in the diff because a crate might change on \`master\` multiple times, and therefore be bumped and republished multiple times, until this PR is merged. Visit \`https://crates.io/crates/\$CRATE/versions\` if you want to see for yourself that all the versions in-between were indeed published.
 
 For additional context see https://github.com/paritytech/releng-scripts/wiki/Crates-publishing-automation#toc.
 "

--- a/publish-crates
+++ b/publish-crates
@@ -610,6 +610,7 @@ main() {
       fi
 
       export SPUB_CRATES_API=http://crates.io/api/v1
+      subpub_args+=(--index-url "https://github.com/rust-lang/crates.io-index")
 
       should_submit_pr=true
       use_clean_environment=true


### PR DESCRIPTION
related to https://github.com/paritytech/substrate/pull/12768

Some parts of it are disabled at the moment, as intended (hint: check for `# TODO` comments). We can enable them progressively after seeing that the check works well for some time.

https://github.com/paritytech/subpub/tree/releng and https://github.com/paritytech/crates.io/tree/releng will remain in a WIP state for a while and I'll refine those in the coming days. They should be in a better state before we move onto publishing to crates.io.