### PR TITLE
Allow for reaching files in the root of the bucket

### DIFF
--- a/cmd/rs/delete.sh
+++ b/cmd/rs/delete.sh
@@ -117,7 +117,7 @@ main() {
     local filename
     filename="$(basename "$location")"
 
-    local remote_destination="$upload_dir/$filename"
+    local remote_destination="${upload_dir:+$upload_dir/}$filename"
 
     if [ ! "${DRY_RUN:-}" ]; then
       log "For input file: $filename"

--- a/cmd/rs/download.sh
+++ b/cmd/rs/download.sh
@@ -118,7 +118,7 @@ main() {
     local filename
     filename="$(basename "$location")"
 
-    local remote_destination="$upload_dir/$filename"
+    local remote_destination="${upload_dir:+$upload_dir/}$filename"
 
     if [ ! "${DRY_RUN:-}" ]; then
       log "For input file: $filename"

--- a/cmd/rs/upload.sh
+++ b/cmd/rs/upload.sh
@@ -219,7 +219,7 @@ main() {
       ;;
     esac
 
-    local remote_destination="$upload_dir/$filename"
+    local remote_destination="${upload_dir:+$upload_dir/}$filename"
 
     if [ ! "${DRY_RUN:-}" ]; then
       log "Uploading file: $file"

--- a/tests/rs.bats
+++ b/tests/rs.bats
@@ -192,3 +192,30 @@ teardown() {
   run "$project_root/rs" "${downloader_default_args[@]}"
   assert_snapshot
 }
+
+@test "empty remote destination directory for download" {
+  touch_snapshot
+  run "$project_root/rs" delete \
+    --bucket test \
+    --dry \
+    custom "" s3 "$fixtures_dir/foo.txt"
+  assert_snapshot
+}
+
+@test "empty remote destination directory for upload" {
+  touch_snapshot
+  run "$project_root/rs" upload \
+    --bucket test \
+    --dry \
+    custom "" s3 "$fixtures_dir/foo.txt"
+  assert_snapshot
+}
+
+@test "empty remote destination directory for delete" {
+  touch_snapshot
+  run "$project_root/rs" download \
+    --bucket test \
+    --dry \
+    custom "" s3 "$fixtures_dir/foo.txt"
+  assert_snapshot
+}

--- a/tests/rs.bats
+++ b/tests/rs.bats
@@ -193,7 +193,7 @@ teardown() {
   assert_snapshot
 }
 
-@test "empty remote destination directory for download" {
+@test "empty remote destination directory for delete" {
   touch_snapshot
   run "$project_root/rs" delete \
     --bucket bucket \
@@ -211,7 +211,7 @@ teardown() {
   assert_snapshot
 }
 
-@test "empty remote destination directory for delete" {
+@test "empty remote destination directory for download" {
   touch_snapshot
   run "$project_root/rs" download \
     --bucket bucket \

--- a/tests/rs.bats
+++ b/tests/rs.bats
@@ -196,7 +196,7 @@ teardown() {
 @test "empty remote destination directory for download" {
   touch_snapshot
   run "$project_root/rs" delete \
-    --bucket test \
+    --bucket bucket \
     --dry \
     custom "" s3 "$fixtures_dir/foo.txt"
   assert_snapshot
@@ -205,7 +205,7 @@ teardown() {
 @test "empty remote destination directory for upload" {
   touch_snapshot
   run "$project_root/rs" upload \
-    --bucket test \
+    --bucket bucket \
     --dry \
     custom "" s3 "$fixtures_dir/foo.txt"
   assert_snapshot
@@ -214,7 +214,7 @@ teardown() {
 @test "empty remote destination directory for delete" {
   touch_snapshot
   run "$project_root/rs" download \
-    --bucket test \
+    --bucket bucket \
     --dry \
     custom "" s3 "$fixtures_dir/foo.txt"
   assert_snapshot

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
@@ -1,3 +1,3 @@
 0
-aws s3 cp -- s3://test/foo.txt .
+aws s3 cp -- s3://bucket/foo.txt .
 Download exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
@@ -1,3 +1,3 @@
 0
-aws s3 cp -- s3://bucket/foo.txt .
-Download exit code: 0
+aws s3 rm s3://bucket/foo.txt
+Deletion exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_delete.snap
@@ -1,0 +1,3 @@
+0
+aws s3 cp -- s3://test/foo.txt .
+Download exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
@@ -1,0 +1,3 @@
+0
+aws s3 rm s3://test/foo.txt
+Deletion exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
@@ -1,3 +1,3 @@
 0
-aws s3 rm s3://test/foo.txt
+aws s3 rm s3://bucket/foo.txt
 Deletion exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_download.snap
@@ -1,3 +1,3 @@
 0
-aws s3 rm s3://bucket/foo.txt
-Deletion exit code: 0
+aws s3 cp -- s3://bucket/foo.txt .
+Download exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_upload.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_upload.snap
@@ -1,0 +1,3 @@
+0
+aws s3 cp --acl public-read -- tests/fixtures/foo.txt s3://test/foo.txt
+Upload exit code: 0

--- a/tests/snapshots/rs-test_empty_remote_destination_directory_for_upload.snap
+++ b/tests/snapshots/rs-test_empty_remote_destination_directory_for_upload.snap
@@ -1,3 +1,3 @@
 0
-aws s3 cp --acl public-read -- tests/fixtures/foo.txt s3://test/foo.txt
+aws s3 cp --acl public-read -- tests/fixtures/foo.txt s3://bucket/foo.txt
 Upload exit code: 0


### PR DESCRIPTION
This allows for reaching files which are placed directly in the root of the bucket, as in `s3://bucket/file`, i.e. not nested within "directories".