### PR TITLE
publish-crates: avoid cleaning up the tmp folder on CI

### DIFF
--- a/publish-crates
+++ b/publish-crates
@@ -32,7 +32,12 @@ system_cargo_config_dir=/.cargo
 on_exit() {
   local exit_code=$?
 
-  rm -rf "$tmp"
+  # it's not necessary to clean up the temporary folder on CI because everything
+  # is cleaned up automatically when the job runner exits
+  if [ ! "${CI:-}" ]; then
+    rm -rf "$tmp"
+  fi
+
   pkill -P "$$" || :
 
   exit "$exit_code"


### PR DESCRIPTION
The `rm: cannot remove XXX: Directory not empty` message is misleading. The error occurs not because the directory has something in it, but because some process it attached to a file within the directory, which makes it so it cannot be removed. See for instance https://stackoverflow.com/questions/64852408/cannot-remove-git-directory-not-empty.

On CI it's not necessary to clean up the temporary folder because it'll be discarded automatically once the job runner exits. The error can still theoretically happen locally, but I'll punt on handling that for now because the script is not supposed to be run locally ([there's a clear warning about that in the comment at the start of the script](https://github.com/paritytech/releng-scripts/blob/b45bd07aaf5e69a08e1be42b61308a554efecb0b/publish-crates#L14)).

closes #31 