### PR TITLE
fix/reserve-crate: Cannot install cargo-generate

### DIFF
--- a/.github/workflows/reserve-crate.yml
+++ b/.github/workflows/reserve-crate.yml
@@ -31,20 +31,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@55c7845fad90d0ae8b2e83715cb900e5e861e8cb # stable branch
+      - name: Install Rust stable toolchain
+        uses: actions-rs/toolchain@v1
         with:
+          profile: minimal
           toolchain: stable
+          override: true
 
       # Put this AFTER installing Rust because the cache uses the current rustc
       # version as its cache key
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@359a70e43a0bb8a13953b04a90f76428b4959bb6 # v2.2.0
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # v2.2.1
         with:
           cache-on-failure: "true"
 
       - name: Install cargo-generate
-        run: cargo install cargo-generate --version 0.17.0
+        run: cargo install cargo-generate --version 0.18.1
 
       - name: Reserve the crate
         env:


### PR DESCRIPTION
- Update rust to the latest stable using `actions-rs`
- Update rust cache to 2.2.1
- Install the latest `cargo-generate` (0.18.1)

Closes #39 .