### PR TITLE
Fix crate reservation

### DIFF
--- a/.github/workflows/reserve-crate.yml
+++ b/.github/workflows/reserve-crate.yml
@@ -46,7 +46,7 @@ jobs:
           cache-on-failure: "true"
 
       - name: Install cargo-generate
-        run: cargo install cargo-generate --version 0.18.1
+        run: cargo install cargo-generate --version 0.18.1 --locked
 
       - name: Reserve the crate
         env:

--- a/.github/workflows/reserve-crate.yml
+++ b/.github/workflows/reserve-crate.yml
@@ -46,7 +46,7 @@ jobs:
           cache-on-failure: "true"
 
       - name: Install cargo-generate
-        run: cargo install cargo-generate --version 0.18.1 --locked
+        run: cargo install cargo-generate --version 0.18.3 --locked -q
 
       - name: Reserve the crate
         env:


### PR DESCRIPTION
Crate reservation currently failing with https://github.com/paritytech/releng-scripts/actions/runs/5535818904 while trying to reserve for https://github.com/paritytech/substrate/pull/14568.  
Fixed by `--locked`.